### PR TITLE
CT-5: Provide a Way to Create/Retrieve/Delete an Artist

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ It will initially take some time to compile and run, but you will see the follow
 
 Now that the service is running you can make requests against is using Postman and `http://localhost:8080/{controller}/{route}`.
 
+> **Note: See the following [Postman Collection](https://www.getpostman.com/collections/ffca384a573896d3a252) for example requests**
+
 ### Unit Tests
 
 Unit tests are written using JUnit 5 in conjunction with [MockK](https://mockk.io/), [Strikt](https://strikt.io/), and [Java Faker](https://github.com/DiUS/java-faker).

--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@ It will initially take some time to compile and run, but you will see the follow
 `Started ConcertTrackerApiApplicationKt in...`
 
 Now that the service is running you can make requests against is using Postman and `http://localhost:8080/{controller}/{route}`.
+
+### Unit Tests
+
+Unit tests are written using JUnit 5 in conjunction with [MockK](https://mockk.io/), [Strikt](https://strikt.io/), and [Java Faker](https://github.com/DiUS/java-faker).
+
+Tests can be run with the following command:
+```bash
+./gradlew test
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("io.mockk:mockk:1.12.0")
+    testImplementation("io.strikt:strikt-core:0.31.0")
+    testImplementation("com.github.javafaker:javafaker:1.0.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.springframework.boot") version "2.5.3"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.5.21"
     kotlin("jvm") version "1.5.21"
     kotlin("plugin.spring") version "1.5.21"
 }
@@ -21,6 +22,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.mockk:mockk:1.12.0")

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
@@ -1,6 +1,6 @@
 package com.evanconell.concerttrackerapi.controller
 
-import com.evanconell.concerttrackerapi.model.Artist
+import com.evanconell.concerttrackerapi.model.data.Artist
 import com.evanconell.concerttrackerapi.model.exception.NotFoundException
 import com.evanconell.concerttrackerapi.service.ArtistService
 import com.evanconell.concerttrackerapi.service.NotFound

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
@@ -1,8 +1,11 @@
 package com.evanconell.concerttrackerapi.controller
 
+import com.evanconell.concerttrackerapi.model.command.CreateArtistCommand
 import com.evanconell.concerttrackerapi.model.data.Artist
 import com.evanconell.concerttrackerapi.model.exception.NotFoundException
+import com.evanconell.concerttrackerapi.model.exception.ValidationException
 import com.evanconell.concerttrackerapi.service.ArtistService
+import com.evanconell.concerttrackerapi.service.CreateArtistResult
 import com.evanconell.concerttrackerapi.service.GetArtistByIdResult
 import org.springframework.web.bind.annotation.*
 
@@ -20,6 +23,16 @@ class ArtistController(private val artistService: ArtistService) {
             when (it) {
                 is GetArtistByIdResult.Success -> it.artist
                 is GetArtistByIdResult.NotFound -> throw NotFoundException(it.message)
+            }
+        }
+    }
+
+    @PostMapping("/artist")
+    fun createArtist(@RequestBody createCommand: CreateArtistCommand): Artist {
+        return artistService.createArtist(createCommand).let {
+            when (it) {
+                is CreateArtistResult.Success -> it.artist
+                is CreateArtistResult.ValidationFailure -> throw ValidationException(it.errors)
             }
         }
     }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
@@ -17,7 +17,7 @@ class ArtistController(private val artistService: ArtistService) {
     @GetMapping("/artist/{id}")
     fun getArtistById(@PathVariable id: String): Artist {
         return artistService.getArtistById(id).let {
-            when(it) {
+            when (it) {
                 is GetArtistByIdResult.Success -> it.artist
                 is GetArtistByIdResult.NotFound -> throw NotFoundException(it.message)
             }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
@@ -1,7 +1,10 @@
 package com.evanconell.concerttrackerapi.controller
 
 import com.evanconell.concerttrackerapi.model.Artist
+import com.evanconell.concerttrackerapi.model.exception.NotFoundException
 import com.evanconell.concerttrackerapi.service.ArtistService
+import com.evanconell.concerttrackerapi.service.NotFound
+import com.evanconell.concerttrackerapi.service.Success
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -12,4 +15,13 @@ class ArtistController(private val artistService: ArtistService) {
         return artistService.getAllArtists()
     }
 
+    @GetMapping("/artist/{id}")
+    fun getArtistById(@PathVariable id: String): Artist {
+        return artistService.getArtistById(id).let {
+            when(it) {
+                is Success -> it.artist
+                is NotFound -> throw NotFoundException(it.message)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
@@ -3,8 +3,7 @@ package com.evanconell.concerttrackerapi.controller
 import com.evanconell.concerttrackerapi.model.data.Artist
 import com.evanconell.concerttrackerapi.model.exception.NotFoundException
 import com.evanconell.concerttrackerapi.service.ArtistService
-import com.evanconell.concerttrackerapi.service.NotFound
-import com.evanconell.concerttrackerapi.service.Success
+import com.evanconell.concerttrackerapi.service.GetArtistByIdResult
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -19,8 +18,8 @@ class ArtistController(private val artistService: ArtistService) {
     fun getArtistById(@PathVariable id: String): Artist {
         return artistService.getArtistById(id).let {
             when(it) {
-                is Success -> it.artist
-                is NotFound -> throw NotFoundException(it.message)
+                is GetArtistByIdResult.Success -> it.artist
+                is GetArtistByIdResult.NotFound -> throw NotFoundException(it.message)
             }
         }
     }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
@@ -1,0 +1,15 @@
+package com.evanconell.concerttrackerapi.controller
+
+import com.evanconell.concerttrackerapi.model.Artist
+import com.evanconell.concerttrackerapi.service.ArtistService
+import org.springframework.web.bind.annotation.*
+
+@RestController
+class ArtistController(private val artistService: ArtistService) {
+
+    @GetMapping("/artist")
+    fun getAllArtists(): List<Artist> {
+        return artistService.getAllArtists()
+    }
+
+}

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/controller/ArtistController.kt
@@ -6,8 +6,12 @@ import com.evanconell.concerttrackerapi.model.exception.NotFoundException
 import com.evanconell.concerttrackerapi.model.exception.ValidationException
 import com.evanconell.concerttrackerapi.service.ArtistService
 import com.evanconell.concerttrackerapi.service.CreateArtistResult
+import com.evanconell.concerttrackerapi.service.DeleteArtistResult
 import com.evanconell.concerttrackerapi.service.GetArtistByIdResult
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+
 
 @RestController
 class ArtistController(private val artistService: ArtistService) {
@@ -33,6 +37,17 @@ class ArtistController(private val artistService: ArtistService) {
             when (it) {
                 is CreateArtistResult.Success -> it.artist
                 is CreateArtistResult.ValidationFailure -> throw ValidationException(it.errors)
+            }
+        }
+    }
+
+
+    @DeleteMapping("/artist/{id}")
+    fun deleteArtistById(@PathVariable id: String): ResponseEntity<Void> {
+        return artistService.deleteArtistById(id).let {
+            when (it) {
+                is DeleteArtistResult.Success -> ResponseEntity<Void>(HttpStatus.NO_CONTENT)
+                is DeleteArtistResult.NotFound -> throw NotFoundException(it.message)
             }
         }
     }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/Artist.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/Artist.kt
@@ -1,0 +1,10 @@
+package com.evanconell.concerttrackerapi.model
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.TypeAlias
+
+@TypeAlias("artist")
+data class Artist(
+        @Id var id: String,
+        var name: String) {
+}

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/command/CreateArtistCommand.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/command/CreateArtistCommand.kt
@@ -1,0 +1,26 @@
+package com.evanconell.concerttrackerapi.model.command
+
+import com.evanconell.concerttrackerapi.model.validation.FieldError
+import com.evanconell.concerttrackerapi.model.validation.ValidationError
+import com.evanconell.concerttrackerapi.model.validation.ValidationResult
+
+class CreateArtistCommand(
+    val name: String
+) {
+    fun validate(): ValidationResult {
+        val errors = mutableListOf<ValidationError>()
+        this.name
+            .takeIf { it.isBlank() }
+            ?.let {
+                errors.add(
+                    ValidationError(
+                        field = this::name.name,
+                        value = it,
+                        message = FieldError.BLANK_OR_EMPTY.message
+                    )
+                )
+            }
+
+        return ValidationResult(errors)
+    }
+}

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/data/Artist.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/data/Artist.kt
@@ -1,4 +1,4 @@
-package com.evanconell.concerttrackerapi.model
+package com.evanconell.concerttrackerapi.model.data
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.TypeAlias

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/data/Artist.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/data/Artist.kt
@@ -5,6 +5,7 @@ import org.springframework.data.annotation.TypeAlias
 
 @TypeAlias("artist")
 data class Artist(
-        @Id var id: String,
-        var name: String) {
+    @Id var id: String,
+    var name: String
+) {
 }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/exception/NotFoundException.kt
@@ -4,4 +4,4 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
 @ResponseStatus(HttpStatus.NOT_FOUND)
-class NotFoundException(msg: String) : RuntimeException(msg)
+class NotFoundException(val msg: String) : RuntimeException(msg)

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/exception/NotFoundException.kt
@@ -1,0 +1,7 @@
+package com.evanconell.concerttrackerapi.model.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+class NotFoundException(msg: String) : RuntimeException(msg)

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/exception/ValidationException.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/exception/ValidationException.kt
@@ -1,0 +1,10 @@
+package com.evanconell.concerttrackerapi.model.exception
+
+import com.evanconell.concerttrackerapi.model.validation.ValidationError
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+class ValidationException(errors: List<ValidationError>) : RuntimeException(Json.encodeToString(errors))

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/exception/ValidationException.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/exception/ValidationException.kt
@@ -7,4 +7,4 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
 @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
-class ValidationException(errors: List<ValidationError>) : RuntimeException(Json.encodeToString(errors))
+class ValidationException(val errors: List<ValidationError>) : RuntimeException(Json.encodeToString(errors))

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/validation/FieldError.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/validation/FieldError.kt
@@ -1,0 +1,5 @@
+package com.evanconell.concerttrackerapi.model.validation
+
+enum class FieldError(val message: String) {
+    BLANK_OR_EMPTY("Field can't be blank or empty.")
+}

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/validation/ValidationResult.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/validation/ValidationResult.kt
@@ -1,0 +1,12 @@
+package com.evanconell.concerttrackerapi.model.validation
+
+sealed class ValidationResult {
+    object Success : ValidationResult()
+    data class Failure(val errors: List<ValidationError>) : ValidationResult()
+}
+
+data class ValidationError(
+    val field: String,
+    val value: Any,
+    val message: String
+)

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/model/validation/ValidationResult.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/model/validation/ValidationResult.kt
@@ -1,12 +1,14 @@
 package com.evanconell.concerttrackerapi.model.validation
 
-sealed class ValidationResult {
-    object Success : ValidationResult()
-    data class Failure(val errors: List<ValidationError>) : ValidationResult()
+import kotlinx.serialization.Serializable
+
+data class ValidationResult(val errors: List<ValidationError>) {
+    fun isValid(): Boolean = errors.isEmpty()
 }
 
+@Serializable
 data class ValidationError(
     val field: String,
-    val value: Any,
+    val value: String,
     val message: String
 )

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/respository/ArtistRepository.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/respository/ArtistRepository.kt
@@ -1,6 +1,6 @@
 package com.evanconell.concerttrackerapi.respository
 
-import com.evanconell.concerttrackerapi.model.Artist
+import com.evanconell.concerttrackerapi.model.data.Artist
 import org.springframework.data.repository.CrudRepository
 
 interface ArtistRepository : CrudRepository<Artist, String> {

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/respository/ArtistRepository.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/respository/ArtistRepository.kt
@@ -1,0 +1,7 @@
+package com.evanconell.concerttrackerapi.respository
+
+import com.evanconell.concerttrackerapi.model.Artist
+import org.springframework.data.repository.CrudRepository
+
+interface ArtistRepository : CrudRepository<Artist, String> {
+}

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
@@ -6,11 +6,25 @@ import org.springframework.stereotype.Service
 
 interface ArtistService {
     fun getAllArtists() : List<Artist>
+    fun getArtistById(id: String) : ArtistServiceResult
+
 }
+
+sealed class ArtistServiceResult
+class Success(val artist: Artist) : ArtistServiceResult()
+class NotFound(val message: String) : ArtistServiceResult()
 
 @Service("artistService")
 class ArtistServiceImpl(
-  private val artistRepo: ArtistRepository
+        private val artistRepo: ArtistRepository
 ): ArtistService {
     override fun getAllArtists(): List<Artist> = artistRepo.findAll().toList()
+
+    override fun getArtistById(id: String) : ArtistServiceResult {
+        return artistRepo
+                .findById(id)
+                .takeIf { it.isPresent }
+                ?.let { Success(it.get()) }
+                ?: NotFound("Artist not found with id $id")
+    }
 }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
@@ -1,0 +1,16 @@
+package com.evanconell.concerttrackerapi.service
+
+import com.evanconell.concerttrackerapi.model.Artist
+import com.evanconell.concerttrackerapi.respository.ArtistRepository
+import org.springframework.stereotype.Service
+
+interface ArtistService {
+    fun getAllArtists() : List<Artist>
+}
+
+@Service("artistService")
+class ArtistServiceImpl(
+  private val artistRepo: ArtistRepository
+): ArtistService {
+    override fun getAllArtists(): List<Artist> = artistRepo.findAll().toList()
+}

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
@@ -1,6 +1,6 @@
 package com.evanconell.concerttrackerapi.service
 
-import com.evanconell.concerttrackerapi.model.Artist
+import com.evanconell.concerttrackerapi.model.data.Artist
 import com.evanconell.concerttrackerapi.respository.ArtistRepository
 import org.springframework.stereotype.Service
 

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
@@ -9,9 +9,11 @@ interface ArtistService {
     fun getArtistById(id: String) : GetArtistByIdResult
 }
 
-sealed class GetArtistByIdResult
-class Success(val artist: Artist) : GetArtistByIdResult()
-class NotFound(val message: String) : GetArtistByIdResult()
+sealed class GetArtistByIdResult {
+    class Success(val artist: Artist) : GetArtistByIdResult()
+    class NotFound(val message: String) : GetArtistByIdResult()
+}
+
 
 @Service("artistService")
 class ArtistServiceImpl(
@@ -23,7 +25,7 @@ class ArtistServiceImpl(
         return artistRepo
                 .findById(id)
                 .takeIf { it.isPresent }
-                ?.let { Success(it.get()) }
-                ?: NotFound("Artist not found with id $id")
+                ?.let { GetArtistByIdResult.Success(it.get()) }
+                ?: GetArtistByIdResult.NotFound("Artist not found with id $id")
     }
 }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
@@ -5,8 +5,8 @@ import com.evanconell.concerttrackerapi.respository.ArtistRepository
 import org.springframework.stereotype.Service
 
 interface ArtistService {
-    fun getAllArtists() : List<Artist>
-    fun getArtistById(id: String) : GetArtistByIdResult
+    fun getAllArtists(): List<Artist>
+    fun getArtistById(id: String): GetArtistByIdResult
 }
 
 sealed class GetArtistByIdResult {
@@ -17,15 +17,15 @@ sealed class GetArtistByIdResult {
 
 @Service("artistService")
 class ArtistServiceImpl(
-        private val artistRepo: ArtistRepository
-): ArtistService {
+    private val artistRepo: ArtistRepository
+) : ArtistService {
     override fun getAllArtists(): List<Artist> = artistRepo.findAll().toList()
 
-    override fun getArtistById(id: String) : GetArtistByIdResult {
+    override fun getArtistById(id: String): GetArtistByIdResult {
         return artistRepo
-                .findById(id)
-                .takeIf { it.isPresent }
-                ?.let { GetArtistByIdResult.Success(it.get()) }
-                ?: GetArtistByIdResult.NotFound("Artist not found with id $id")
+            .findById(id)
+            .takeIf { it.isPresent }
+            ?.let { GetArtistByIdResult.Success(it.get()) }
+            ?: GetArtistByIdResult.NotFound("Artist not found with id $id")
     }
 }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
@@ -6,13 +6,12 @@ import org.springframework.stereotype.Service
 
 interface ArtistService {
     fun getAllArtists() : List<Artist>
-    fun getArtistById(id: String) : ArtistServiceResult
-
+    fun getArtistById(id: String) : GetArtistByIdResult
 }
 
-sealed class ArtistServiceResult
-class Success(val artist: Artist) : ArtistServiceResult()
-class NotFound(val message: String) : ArtistServiceResult()
+sealed class GetArtistByIdResult
+class Success(val artist: Artist) : GetArtistByIdResult()
+class NotFound(val message: String) : GetArtistByIdResult()
 
 @Service("artistService")
 class ArtistServiceImpl(
@@ -20,7 +19,7 @@ class ArtistServiceImpl(
 ): ArtistService {
     override fun getAllArtists(): List<Artist> = artistRepo.findAll().toList()
 
-    override fun getArtistById(id: String) : ArtistServiceResult {
+    override fun getArtistById(id: String) : GetArtistByIdResult {
         return artistRepo
                 .findById(id)
                 .takeIf { it.isPresent }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
@@ -11,6 +11,7 @@ interface ArtistService {
     fun getAllArtists(): List<Artist>
     fun getArtistById(id: String): GetArtistByIdResult
     fun createArtist(createCommand: CreateArtistCommand): CreateArtistResult
+    fun deleteArtistById(id: String): DeleteArtistResult
 }
 
 sealed class GetArtistByIdResult {
@@ -21,6 +22,11 @@ sealed class GetArtistByIdResult {
 sealed class CreateArtistResult {
     data class Success(val artist: Artist) : CreateArtistResult()
     data class ValidationFailure(val errors: List<ValidationError>) : CreateArtistResult()
+}
+
+sealed class DeleteArtistResult {
+    object Success : DeleteArtistResult()
+    data class NotFound(val message: String) : DeleteArtistResult()
 }
 
 
@@ -49,5 +55,18 @@ class ArtistServiceImpl(
                     name = createCommand.name
                 )
             ).let { CreateArtistResult.Success(it) }
+    }
+
+    override fun deleteArtistById(id: String): DeleteArtistResult {
+        return getArtistById(id)
+            .let {
+                when (it) {
+                    is GetArtistByIdResult.Success -> {
+                        artistRepo.deleteById(id)
+                        DeleteArtistResult.Success
+                    }
+                    is GetArtistByIdResult.NotFound -> DeleteArtistResult.NotFound(it.message)
+                }
+            }
     }
 }

--- a/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
+++ b/src/main/kotlin/com/evanconell/concerttrackerapi/service/ArtistService.kt
@@ -1,17 +1,26 @@
 package com.evanconell.concerttrackerapi.service
 
+import com.evanconell.concerttrackerapi.model.command.CreateArtistCommand
 import com.evanconell.concerttrackerapi.model.data.Artist
+import com.evanconell.concerttrackerapi.model.validation.ValidationError
 import com.evanconell.concerttrackerapi.respository.ArtistRepository
+import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 
 interface ArtistService {
     fun getAllArtists(): List<Artist>
     fun getArtistById(id: String): GetArtistByIdResult
+    fun createArtist(createCommand: CreateArtistCommand): CreateArtistResult
 }
 
 sealed class GetArtistByIdResult {
-    class Success(val artist: Artist) : GetArtistByIdResult()
-    class NotFound(val message: String) : GetArtistByIdResult()
+    data class Success(val artist: Artist) : GetArtistByIdResult()
+    data class NotFound(val message: String) : GetArtistByIdResult()
+}
+
+sealed class CreateArtistResult {
+    data class Success(val artist: Artist) : CreateArtistResult()
+    data class ValidationFailure(val errors: List<ValidationError>) : CreateArtistResult()
 }
 
 
@@ -27,5 +36,18 @@ class ArtistServiceImpl(
             .takeIf { it.isPresent }
             ?.let { GetArtistByIdResult.Success(it.get()) }
             ?: GetArtistByIdResult.NotFound("Artist not found with id $id")
+    }
+
+    override fun createArtist(createCommand: CreateArtistCommand): CreateArtistResult {
+        return createCommand
+            .validate()
+            .takeUnless { it.isValid() }
+            ?.let { CreateArtistResult.ValidationFailure(it.errors) }
+            ?: artistRepo.save(
+                Artist(
+                    id = ObjectId().toHexString(),
+                    name = createCommand.name
+                )
+            ).let { CreateArtistResult.Success(it) }
     }
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerApiApplicationTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerApiApplicationTests.kt
@@ -10,5 +10,5 @@ class ConcertTrackerApiApplicationTests {
     fun contextLoads() {
     }
 
-    
+
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerFaker.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerFaker.kt
@@ -1,0 +1,19 @@
+package com.evanconell.concerttrackerapi
+
+import com.evanconell.concerttrackerapi.model.data.Artist
+import com.github.javafaker.Faker
+import org.bson.types.ObjectId
+
+object ConcertTrackerFaker : Faker() {
+
+    init {
+        println("Initializing Faker")
+    }
+
+    fun id(): String = ObjectId.get().toHexString()
+
+    fun ctArtist(): Artist = Artist(
+            id = id(),
+            name = artist().name()
+    )
+}

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerFaker.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerFaker.kt
@@ -2,6 +2,7 @@ package com.evanconell.concerttrackerapi
 
 import com.evanconell.concerttrackerapi.model.command.CreateArtistCommand
 import com.evanconell.concerttrackerapi.model.data.Artist
+import com.evanconell.concerttrackerapi.model.validation.ValidationError
 import com.github.javafaker.Faker
 import org.bson.types.ObjectId
 
@@ -19,4 +20,10 @@ object ConcertTrackerFaker : Faker() {
     )
 
     fun ctCreateArtistCommand(): CreateArtistCommand = CreateArtistCommand(name = artist().name())
+
+    fun ctValidationError(): ValidationError = ValidationError(
+        field = name().firstName(),
+        value = name().lastName(),
+        message = shakespeare().hamletQuote()
+    )
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerFaker.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerFaker.kt
@@ -1,5 +1,6 @@
 package com.evanconell.concerttrackerapi
 
+import com.evanconell.concerttrackerapi.model.command.CreateArtistCommand
 import com.evanconell.concerttrackerapi.model.data.Artist
 import com.github.javafaker.Faker
 import org.bson.types.ObjectId
@@ -16,4 +17,6 @@ object ConcertTrackerFaker : Faker() {
         id = id(),
         name = artist().name()
     )
+
+    fun ctCreateArtistCommand(): CreateArtistCommand = CreateArtistCommand(name = artist().name())
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerFaker.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerFaker.kt
@@ -13,7 +13,7 @@ object ConcertTrackerFaker : Faker() {
     fun id(): String = ObjectId.get().toHexString()
 
     fun ctArtist(): Artist = Artist(
-            id = id(),
-            name = artist().name()
+        id = id(),
+        name = artist().name()
     )
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerTestBase.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/ConcertTrackerTestBase.kt
@@ -1,0 +1,5 @@
+package com.evanconell.concerttrackerapi
+
+open class ConcertTrackerTestBase {
+    val faker = ConcertTrackerFaker
+}

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/controller/ArtistControllerTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/controller/ArtistControllerTests.kt
@@ -1,0 +1,147 @@
+package com.evanconell.concerttrackerapi.controller
+
+import com.evanconell.concerttrackerapi.ConcertTrackerTestBase
+import com.evanconell.concerttrackerapi.model.exception.NotFoundException
+import com.evanconell.concerttrackerapi.model.exception.ValidationException
+import com.evanconell.concerttrackerapi.service.ArtistService
+import com.evanconell.concerttrackerapi.service.CreateArtistResult
+import com.evanconell.concerttrackerapi.service.DeleteArtistResult
+import com.evanconell.concerttrackerapi.service.GetArtistByIdResult
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import strikt.api.expectCatching
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFailure
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ArtistControllerTests : ConcertTrackerTestBase() {
+    private lateinit var artistServiceMock: ArtistService
+    private lateinit var controller: ArtistController
+
+    @BeforeAll
+    fun init() {
+        artistServiceMock = mockk()
+        controller = ArtistController(artistServiceMock)
+    }
+
+    @BeforeEach
+    fun setUp() = clearAllMocks()
+
+    @Test
+    fun getAllArtists_returnsArtistList() {
+        // Arrange
+        val expected = listOf(faker.ctArtist(), faker.ctArtist())
+        every { artistServiceMock.getAllArtists() } returns expected
+
+        // Act
+        val actual = controller.getAllArtists()
+
+        // Assert
+        verify { artistServiceMock.getAllArtists() }
+        expectThat(actual)
+            .containsExactly(expected)
+    }
+
+    @Test
+    fun getArtistById_returnsArtist_whenFound() {
+        // Arrange
+        val id = faker.id()
+        val expected = faker.ctArtist()
+        every { artistServiceMock.getArtistById(id) } returns GetArtistByIdResult.Success(expected)
+
+        // Act
+        val actual = controller.getArtistById(id)
+
+        // Assert
+        verify { artistServiceMock.getArtistById(id) }
+        expectThat(actual)
+            .isEqualTo(expected)
+    }
+
+    @Test
+    fun getArtistById_throws_whenNotFound() {
+        // Arrange
+        val id = faker.id()
+        val expectedError = faker.shakespeare().asYouLikeItQuote()
+        every { artistServiceMock.getArtistById(id) } returns GetArtistByIdResult.NotFound(expectedError)
+
+        // Act & Assert
+        expectCatching { controller.getArtistById(id) }
+            .isFailure()
+            .isA<NotFoundException>()
+            .get(NotFoundException::msg)
+            .isEqualTo(expectedError)
+    }
+
+    @Test
+    fun createArtist_returnsArtist_whenCreated() {
+        // Arrange
+        val command = faker.ctCreateArtistCommand()
+        val expected = faker.ctArtist()
+        every { artistServiceMock.createArtist(command) } returns CreateArtistResult.Success(expected)
+
+        // Act
+        val actual = controller.createArtist(command)
+
+        // Assert
+        verify { artistServiceMock.createArtist(command) }
+        expectThat(actual)
+            .isEqualTo(expected)
+    }
+
+    @Test
+    fun createArtist_throws_whenValidationError() {
+        // Arrange
+        val command = faker.ctCreateArtistCommand()
+        val expectedErrors = listOf(faker.ctValidationError(), faker.ctValidationError())
+        every { artistServiceMock.createArtist(command) } returns CreateArtistResult.ValidationFailure(expectedErrors)
+
+        // Act & Assert
+        expectCatching { controller.createArtist(command) }
+            .isFailure()
+            .isA<ValidationException>()
+            .get(ValidationException::errors)
+            .containsExactly(expectedErrors)
+    }
+
+    @Test
+    fun deleteArtistById_returnsVoid_whenFound() {
+        // Arrange
+        val id = faker.id()
+        every { artistServiceMock.deleteArtistById(id) } returns DeleteArtistResult.Success
+
+        // Act
+        val actual = controller.deleteArtistById(id)
+
+        // Assert
+        verify { artistServiceMock.deleteArtistById(id) }
+        expectThat(actual)
+            .isEqualTo(ResponseEntity<Void>(HttpStatus.NO_CONTENT))
+    }
+
+    @Test
+    fun deleteArtistById_throws_whenNotFound() {
+        // Arrange
+        val id = faker.id()
+        val expectedError = faker.shakespeare().asYouLikeItQuote()
+        every { artistServiceMock.deleteArtistById(id) } returns DeleteArtistResult.NotFound(expectedError)
+
+        // Act & Assert
+        expectCatching { controller.deleteArtistById(id) }
+            .isFailure()
+            .isA<NotFoundException>()
+            .get(NotFoundException::msg)
+            .isEqualTo(expectedError)
+    }
+}

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/model/command/CreateArtistCommandTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/model/command/CreateArtistCommandTests.kt
@@ -1,0 +1,54 @@
+package com.evanconell.concerttrackerapi.model.command
+
+import com.evanconell.concerttrackerapi.ConcertTrackerTestBase
+import com.evanconell.concerttrackerapi.model.validation.FieldError
+import com.evanconell.concerttrackerapi.model.validation.ValidationError
+import com.evanconell.concerttrackerapi.model.validation.ValidationResult
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.isA
+import strikt.assertions.isEmpty
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CreateArtistCommandTests : ConcertTrackerTestBase() {
+
+    @Test
+    fun validate_hasNoErrors_forValidCommand() {
+        // Arrange
+        val command = faker.ctCreateArtistCommand()
+
+        // Act
+        val actual = command.validate()
+
+        // Assert
+        expectThat(actual)
+            .isA<ValidationResult>()
+            .get(ValidationResult::errors).and {
+                this.isEmpty()
+            }
+    }
+
+    @Test
+    fun validate_addsError_forBlankName() {
+        // Arrange
+        val command = CreateArtistCommand(name = "")
+        val expectedError = ValidationError(
+            field = CreateArtistCommand::name.name,
+            value = "",
+            message = FieldError.BLANK_OR_EMPTY.message
+        )
+
+        // Act
+        val actual = command.validate()
+
+        // Assert
+        expectThat(actual)
+            .isA<ValidationResult>()
+            .get(ValidationResult::errors).and {
+                this.containsExactly(expectedError)
+            }
+    }
+}

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/model/validation/ValidationResultTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/model/validation/ValidationResultTests.kt
@@ -1,0 +1,37 @@
+package com.evanconell.concerttrackerapi.model.validation
+
+import com.evanconell.concerttrackerapi.ConcertTrackerTestBase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ValidationResultTests : ConcertTrackerTestBase() {
+
+    @Test
+    fun isValid_returnsTrue_whenErrorsIsEmpty() {
+        // Arrange
+        val validationResult = ValidationResult(emptyList())
+
+        // Act
+        val actual = validationResult.isValid()
+
+        // Assert
+        expectThat(actual).isTrue()
+    }
+
+    @Test
+    fun isValid_returnsFalse_whenErrorsIsNotEmpty() {
+        // Arrange
+        val validationResult = ValidationResult(listOf(faker.ctValidationError()))
+
+        // Act
+        val actual = validationResult.isValid()
+
+        // Assert
+        expectThat(actual).isFalse()
+    }
+}

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
@@ -135,4 +135,40 @@ class ArtistServiceTests : ConcertTrackerTestBase() {
             .get(CreateArtistResult.ValidationFailure::errors)
             .containsExactly(expectedValidationError)
     }
+
+    @Test
+    fun deleteArtistById_returnsSuccess_whenExists() {
+        // Arrange
+        val id = faker.id()
+        val expected = faker.ctArtist()
+        every { repoMock.findById(id) } returns Optional.of(expected)
+        every { repoMock.deleteById(id) } returns Unit
+
+        // Act
+        val actual = service.deleteArtistById(id)
+
+        // Assert
+        verify { repoMock.findById(id) }
+        verify { repoMock.deleteById(id) }
+        expectThat(actual)
+            .isA<DeleteArtistResult.Success>()
+    }
+
+    @Test
+    fun deleteArtistById_returnsNotFound_whenDoesNotExist() {
+        // Arrange
+        val id = faker.id()
+        every { repoMock.findById(id) } returns Optional.empty()
+
+        // Act
+        val actual = service.deleteArtistById(id)
+
+        // Assert
+        verify { repoMock.findById(id) }
+        verify(exactly = 0) { repoMock.deleteById(any()) }
+        expectThat(actual)
+            .isA<DeleteArtistResult.NotFound>()
+            .get(DeleteArtistResult.NotFound::message)
+            .isEqualTo("Artist not found with id $id")
+    }
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
@@ -59,8 +59,8 @@ class ArtistServiceTests: ConcertTrackerTestBase() {
         // Assert
         verify { repoMock.findById(id) }
         expectThat(actual)
-                .isA<Success>()
-                .get(Success::artist)
+                .isA<GetArtistByIdResult.Success>()
+                .get(GetArtistByIdResult.Success::artist)
                 .isEqualTo(expected)
     }
 
@@ -76,8 +76,8 @@ class ArtistServiceTests: ConcertTrackerTestBase() {
         // Assert
         verify { repoMock.findById(id) }
         expectThat(actual)
-                .isA<NotFound>()
-                .get(NotFound::message)
+                .isA<GetArtistByIdResult.NotFound>()
+                .get(GetArtistByIdResult.NotFound::message)
                 .isEqualTo("Artist not found with id $id")
     }
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import strikt.api.expectThat
 import strikt.assertions.containsExactly
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ArtistServiceTests: ConcertTrackerTestBase() {
@@ -40,5 +43,41 @@ class ArtistServiceTests: ConcertTrackerTestBase() {
         verify { repoMock.findAll() }
         expectThat(actual)
                 .containsExactly(expected)
+    }
+
+
+    @Test
+    fun getArtistById_returnsSuccess_whenExists() {
+        // Arrange
+        val id = faker.id()
+        val expected = faker.ctArtist()
+        every { repoMock.findById(id) } returns Optional.of(expected)
+
+        // Act
+        val actual = service.getArtistById(id)
+
+        // Assert
+        verify { repoMock.findById(id) }
+        expectThat(actual)
+                .isA<Success>()
+                .get(Success::artist)
+                .isEqualTo(expected)
+    }
+
+    @Test
+    fun getArtistById_returnsNotFound_whenDoesNotExist() {
+        // Arrange
+        val id = faker.id()
+        every { repoMock.findById(id) } returns Optional.empty()
+
+        // Act
+        val actual = service.getArtistById(id)
+
+        // Assert
+        verify { repoMock.findById(id) }
+        expectThat(actual)
+                .isA<NotFound>()
+                .get(NotFound::message)
+                .isEqualTo("Artist not found with id $id")
     }
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
@@ -2,7 +2,10 @@ package com.evanconell.concerttrackerapi.service
 
 import com.evanconell.concerttrackerapi.ConcertTrackerTestBase
 import com.evanconell.concerttrackerapi.respository.ArtistRepository
-import io.mockk.*
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -14,7 +17,7 @@ import strikt.assertions.isEqualTo
 import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ArtistServiceTests: ConcertTrackerTestBase() {
+class ArtistServiceTests : ConcertTrackerTestBase() {
     private lateinit var repoMock: ArtistRepository
     private lateinit var service: ArtistService
 
@@ -31,8 +34,8 @@ class ArtistServiceTests: ConcertTrackerTestBase() {
     fun getAllArtists_returnsList() {
         // Arrange
         val expected = listOf(
-                faker.ctArtist(),
-                faker.ctArtist()
+            faker.ctArtist(),
+            faker.ctArtist()
         )
         every { repoMock.findAll() } returns expected
 
@@ -42,7 +45,7 @@ class ArtistServiceTests: ConcertTrackerTestBase() {
         // Assert
         verify { repoMock.findAll() }
         expectThat(actual)
-                .containsExactly(expected)
+            .containsExactly(expected)
     }
 
 
@@ -59,9 +62,9 @@ class ArtistServiceTests: ConcertTrackerTestBase() {
         // Assert
         verify { repoMock.findById(id) }
         expectThat(actual)
-                .isA<GetArtistByIdResult.Success>()
-                .get(GetArtistByIdResult.Success::artist)
-                .isEqualTo(expected)
+            .isA<GetArtistByIdResult.Success>()
+            .get(GetArtistByIdResult.Success::artist)
+            .isEqualTo(expected)
     }
 
     @Test
@@ -76,8 +79,8 @@ class ArtistServiceTests: ConcertTrackerTestBase() {
         // Assert
         verify { repoMock.findById(id) }
         expectThat(actual)
-                .isA<GetArtistByIdResult.NotFound>()
-                .get(GetArtistByIdResult.NotFound::message)
-                .isEqualTo("Artist not found with id $id")
+            .isA<GetArtistByIdResult.NotFound>()
+            .get(GetArtistByIdResult.NotFound::message)
+            .isEqualTo("Artist not found with id $id")
     }
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
@@ -82,9 +82,12 @@ class ArtistServiceTests : ConcertTrackerTestBase() {
     }
 
     @Test
-    fun createArtist_returnsArtist_whenGivenValidCommand() {
+    fun createArtist_returnsSuccess_whenGivenValidCommand() {
         // Arrange
-        val createArtistCommand = faker.ctCreateArtistCommand()
+        val createArtistCommand = mockk<CreateArtistCommand>()
+        val expectedArtistName = faker.artist().name()
+        every { createArtistCommand.validate() } returns ValidationResult(emptyList())
+        every { createArtistCommand.name } returns expectedArtistName
         val capturedArtist = slot<Artist>()
         val expected = faker.ctArtist()
         every { repoMock.save(capture(capturedArtist)) } returns expected
@@ -93,6 +96,7 @@ class ArtistServiceTests : ConcertTrackerTestBase() {
         val actual = service.createArtist(createArtistCommand)
 
         // Assert
+        verify { createArtistCommand.validate() }
         expectThat(actual)
             .isA<CreateArtistResult.Success>()
             .get(CreateArtistResult.Success::artist)
@@ -102,7 +106,7 @@ class ArtistServiceTests : ConcertTrackerTestBase() {
 
         expectThat(capturedArtist.captured) {
             get { id }.isNotEmpty()
-            get { name }.isEqualTo(createArtistCommand.name)
+            get { name }.isEqualTo(expectedArtistName)
         }
     }
 }

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
@@ -1,0 +1,44 @@
+package com.evanconell.concerttrackerapi.service
+
+import com.evanconell.concerttrackerapi.ConcertTrackerTestBase
+import com.evanconell.concerttrackerapi.respository.ArtistRepository
+import io.mockk.*
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ArtistServiceTests: ConcertTrackerTestBase() {
+    private lateinit var repoMock: ArtistRepository
+    private lateinit var service: ArtistService
+
+    @BeforeAll
+    fun init() {
+        repoMock = mockk()
+        service = ArtistServiceImpl(repoMock)
+    }
+
+    @BeforeEach
+    fun setUp() = clearAllMocks()
+
+    @Test
+    fun getAllArtists_returnsList() {
+        // Arrange
+        val expected = listOf(
+                faker.ctArtist(),
+                faker.ctArtist()
+        )
+        every { repoMock.findAll() } returns expected
+
+        // Act
+        val actual = service.getAllArtists()
+
+        // Assert
+        verify { repoMock.findAll() }
+        expectThat(actual)
+                .containsExactly(expected)
+    }
+}

--- a/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
+++ b/src/test/kotlin/com/evanconell/concerttrackerapi/service/ArtistServiceTests.kt
@@ -117,11 +117,7 @@ class ArtistServiceTests : ConcertTrackerTestBase() {
     fun createArtist_returnsValidationFailure_whenGivenCommandIsInvalid() {
         // Arrange
         val createArtistCommand = mockk<CreateArtistCommand>()
-        val expectedValidationError = ValidationError(
-            field = faker.name().firstName(),
-            value = faker.name().lastName(),
-            message = faker.shakespeare().hamletQuote()
-        )
+        val expectedValidationError = faker.ctValidationError()
         every { createArtistCommand.validate() } returns ValidationResult(listOf(expectedValidationError))
 
         // Act


### PR DESCRIPTION
[CT-5: Provide a Way to Create/Retrieve/Delete an Artist](https://econell.atlassian.net/browse/CT-5)

The goal of this body of work is to provide the basic CR~U~D (**_update to come in follow up card_**) for the `Artist` object. In its initial form this will only contain 2 variables,`id` and `name`. More key data points will be added later.

Along with the base data structure/CRUD operations for `Artist`, this body of work sets up the base structure for application as well as the unit tests

Object structure:
```
artist: {
  id: String (ObjectId)
  name: String
}
```

The desired endpoints are as follows:

**Retrieve:**
- GET request to `/artist` returns `List<Artist>`
- GET request to `/artist/{id}` returns `Artist` or 404 if not found

**Create:**
- POST request to `/artist` with `CreateArtistCommand` payload returns `Artist` on valid request, 422 with errors on validation failure
```
createArtistCommand: {
  name: String
}
```

**Delete:**
- DELETE request to `/artist/{id}` returns 204 on success or 404 if not found

See [Postman collection](https://www.getpostman.com/collections/ffca384a573896d3a252) for example requests.